### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -457,8 +457,13 @@ def serve_public(path):
             return send_from_directory(public_folder, 'vpn_blocked.html'), 403
     
     app.logger.info(f"Requested path: {path}")
-    full_path = os.path.join(public_folder, path)
+    normalized_path = os.path.normpath(path)
+    full_path = os.path.join(public_folder, normalized_path)
     app.logger.info(f"Full path: {full_path}")
+
+    if not full_path.startswith(public_folder):
+        app.logger.warning(f"Attempted path traversal attack: {path}")
+        return send_from_directory(public_folder, 'Access_Denied.html'), 403
 
     if os.path.isdir(full_path):
         app.logger.info(f"Path is a directory, serving index.html from {full_path}")


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/2](https://github.com/fdseilix/My-website/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We will normalize the path using `os.path.normpath` to remove any ".." segments and then check that the normalized path starts with the root folder. This will prevent directory traversal attacks.

1. Normalize the `path` variable using `os.path.normpath`.
2. Construct the `full_path` using the normalized `path`.
3. Check that the `full_path` starts with the `public_folder` to ensure it is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
