### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -9,6 +9,7 @@ import base64
 import bcrypt
 import mysql.connector
 from flask import Flask, jsonify, request, send_file, current_app, send_from_directory, render_template, abort, session, redirect, render_template_string, url_for
+import logging
 from flask_cors import CORS
 from dotenv import load_dotenv
 import time
@@ -1666,7 +1667,8 @@ def Grant_Mod():
         return {"message": "Moderator status granted successfully to user"}, 200
     except Exception as e:
         conn.rollback()
-        return {"message": f"Failed to grant moderator status: {str(e)}"}, 500
+        current_app.logger.error(f"Failed to grant moderator status: {str(e)}")
+        return {"message": "Failed to grant moderator status due to an internal error"}, 500
 
 @app.route('/api/math/RevokeMod', methods=['PATCH'])
 @check_blocked_ip
@@ -1688,7 +1690,8 @@ def Revoke_Mod():
         return {"message": "Moderator status revoked successfully from user"}, 200
     except Exception as e:
         conn.rollback()
-        return {"message": f"Failed to revoke moderator status: {str(e)}"}, 500
+        current_app.logger.error(f"Failed to revoke moderator status: {str(e)}")
+        return {"message": "Failed to revoke moderator status due to an internal error"}, 500
 #Chat endpoints----------------------------------------------------------
 
 @app.route('/api/math/admin/get_messages', methods=['GET'])


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/10](https://github.com/fdseilix/My-website/security/code-scanning/10)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

- Modify the exception handling in the `Grant_Mod` and `Revoke_Mod` functions to log the detailed error message and return a generic error message to the user.
- Add an import for the `logging` module to handle logging the error messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
