### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -995,7 +995,8 @@ def signup():
         }, 201
     except Exception as e:
         conn.rollback()
-        return {"message": f"Internal server error: {str(e)}"}, 500
+        current_app.logger.error(f"Exception occurred: {str(e)}")
+        return {"message": "Internal server error"}, 500
     finally:
         cursor.close()
         conn.close()


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/4](https://github.com/fdseilix/My-website/security/code-scanning/4)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the response.

- Modify the exception handling block to log the detailed error message.
- Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
