### PR TITLE
Fix code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -1500,7 +1500,7 @@ def get_user_detail():
 
     except Exception as e:
         app.logger.error(f"An error occurred in get_user_detail: {str(e)}")
-        return jsonify({"message": f"An error occurred: {str(e)}"}), 500
+        return jsonify({"message": "An internal error has occurred!"}), 500
 
     finally:
         cursor.close()


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/6](https://github.com/fdseilix/My-website/security/code-scanning/6)

To fix the problem, we need to modify the error handling in the `get_user_detail` function to ensure that detailed error information is not exposed to the end user. Instead, we will log the detailed error message on the server side and return a generic error message to the user.

- Replace the line that returns the detailed error message to the user with a line that returns a generic error message.
- Ensure that the detailed error message is still logged on the server side for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
