### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -1645,8 +1645,8 @@ def verify_moderator_login_key():
             return {"message": "Invalid login key"}, 401
 
     except Exception as e:
-        print(e)
-        return jsonify({"message": f"Internal server error: {str(e)}"}), 500
+        current_app.logger.error(f"Internal server error: {str(e)}")
+        return jsonify({"message": "An internal error has occurred"}), 500
     
 @app.route('/api/math/GrantMod', methods=['PATCH'])
 @check_blocked_ip


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/8](https://github.com/fdseilix/My-website/security/code-scanning/8)

To fix the problem, we should avoid returning the exception details directly to the user. Instead, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to diagnose issues.

- Modify the code in `scatterbox.dev/api.py` to log the exception using `current_app.logger.error` and return a generic error message.
- Ensure that the logging captures sufficient details for debugging without exposing them to the end user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
