### PR TITLE
Fix code scanning alert no. 21: Full server-side request forgery

### DIFF
--- a/scatterbox.dev/api.py
+++ b/scatterbox.dev/api.py
@@ -1,7 +1,7 @@
 import os
 import random
 import string
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 import uuid
 import datetime
 import base64
@@ -365,6 +365,12 @@ def mirror_request():
         return "Error: bad 'key' header.", 400
     if not target_url:
         return "Error: Missing 'url' header.", 400
+
+    # Validate the target URL
+    allowed_domains = ["example.com", "another-allowed-domain.com"]
+    parsed_url = urlparse(target_url)
+    if parsed_url.hostname not in allowed_domains:
+        return "Error: 'url' header points to an unauthorized domain.", 400
 
     # Prepare the forwarded request
     headers = {key: value for key, value in request.headers if key.lower() != 'host'}


### PR DESCRIPTION
Fixes [https://github.com/fdseilix/My-website/security/code-scanning/21](https://github.com/fdseilix/My-website/security/code-scanning/21)

To fix the SSRF vulnerability, we need to validate the `target_url` to ensure it points to an allowed domain or endpoint. This can be achieved by maintaining a whitelist of allowed domains and checking the `target_url` against this list before making the request. 

1. Create a list of allowed domains.
2. Parse the `target_url` and extract the domain.
3. Check if the extracted domain is in the list of allowed domains.
4. Only proceed with the request if the domain is allowed; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
